### PR TITLE
Removing Unused Controller Ports from Node

### DIFF
--- a/compose/kraft/multi-node-docker-compose.yml
+++ b/compose/kraft/multi-node-docker-compose.yml
@@ -52,7 +52,6 @@ services:
     container_name: node2
     ports:
       - "29092:29092"
-      - "19092:19092"
       - "9092:9092"
       - "9102:9102"
     environment:


### PR DESCRIPTION
This node is only serving as a broker so there is no need to expose a controller port.